### PR TITLE
Add Unity iOS FastVLM plugin

### DIFF
--- a/unity/Plugins/iOS/FastVLMUnityBridge.swift
+++ b/unity/Plugins/iOS/FastVLMUnityBridge.swift
@@ -1,0 +1,142 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import CoreImage
+import Darwin
+import Foundation
+
+private let unityRunner = FastVLMUnityRunner()
+private let imageConverter = FastVLMUnityImageConverter()
+
+typealias FastVLMUnityStatusCallback = @convention(c) (UnsafeMutablePointer<CChar>?) -> Void
+typealias FastVLMUnityResultCallback = @convention(c) (
+    Int32, UnsafeMutablePointer<CChar>?, UnsafeMutablePointer<CChar>?
+) -> Void
+
+@_cdecl("FastVLMUnity_Configure")
+public func FastVLMUnity_Configure(_ modelDirectoryPointer: UnsafePointer<CChar>?) {
+    let path = modelDirectoryPointer.flatMap { String(cString: $0) } ?? ""
+    Task {
+        await unityRunner.configure(modelDirectoryPath: path)
+    }
+}
+
+@_cdecl("FastVLMUnity_SetGenerationOptions")
+public func FastVLMUnity_SetGenerationOptions(_ temperature: Float, _ maxTokens: Int32) {
+    Task {
+        await unityRunner.setGenerationOptions(temperature: temperature, maxTokens: Int(maxTokens))
+    }
+}
+
+@_cdecl("FastVLMUnity_SetCancelOnNewRequest")
+public func FastVLMUnity_SetCancelOnNewRequest(_ cancelOnNewRequest: Int32) {
+    Task {
+        await unityRunner.setCancelOnNewRequest(cancelOnNewRequest != 0)
+    }
+}
+
+@_cdecl("FastVLMUnity_LoadModel")
+public func FastVLMUnity_LoadModel(_ callback: FastVLMUnityStatusCallback?) {
+    guard let callback else { return }
+
+    Task.detached(priority: .userInitiated) {
+        do {
+            try await unityRunner.loadModel()
+            await MainActor.run {
+                callback(nil)
+            }
+        } catch {
+            let message = createCString(from: error.localizedDescription)
+            await MainActor.run {
+                callback(message)
+            }
+        }
+    }
+}
+
+@_cdecl("FastVLMUnity_ProcessImage")
+public func FastVLMUnity_ProcessImage(
+    _ requestId: Int32,
+    _ pixelDataPointer: UnsafeRawPointer?,
+    _ width: Int32,
+    _ height: Int32,
+    _ bytesPerRow: Int32,
+    _ formatRawValue: Int32,
+    _ flipVertical: Int32,
+    _ promptPointer: UnsafePointer<CChar>?,
+    _ callback: FastVLMUnityResultCallback?
+) {
+    guard let callback else { return }
+
+    guard let pixelDataPointer else {
+        let errorPointer = createCString(from: FastVLMUnityError.invalidPixelBuffer.localizedDescription)
+        Task { @MainActor in
+            callback(requestId, nil, errorPointer)
+        }
+        return
+    }
+
+    guard width > 0, height > 0, bytesPerRow > 0 else {
+        let errorPointer = createCString(from: FastVLMUnityError.invalidDimensions.localizedDescription)
+        Task { @MainActor in
+            callback(requestId, nil, errorPointer)
+        }
+        return
+    }
+
+    guard let format = FastVLMUnityColorFormat(rawValue: Int(formatRawValue)) else {
+        let errorPointer = createCString(from: FastVLMUnityError.unsupportedPixelFormat.localizedDescription)
+        Task { @MainActor in
+            callback(requestId, nil, errorPointer)
+        }
+        return
+    }
+
+    let prompt = promptPointer.flatMap { String(cString: $0) } ?? ""
+    let length = Int(bytesPerRow) * Int(height)
+    let data = Data(bytes: pixelDataPointer, count: length)
+
+    Task.detached(priority: .userInitiated) {
+        do {
+            let ciImage = try imageConverter.makeImage(
+                from: data,
+                width: Int(width),
+                height: Int(height),
+                bytesPerRow: Int(bytesPerRow),
+                format: format,
+                flipVertical: flipVertical != 0
+            )
+
+            let output = try await unityRunner.generate(ciImage: ciImage, prompt: prompt)
+            let resultPointer = createCString(from: output)
+            await MainActor.run {
+                callback(requestId, resultPointer, nil)
+            }
+        } catch {
+            let errorPointer = createCString(from: error.localizedDescription)
+            await MainActor.run {
+                callback(requestId, nil, errorPointer)
+            }
+        }
+    }
+}
+
+@_cdecl("FastVLMUnity_CancelAll")
+public func FastVLMUnity_CancelAll() {
+    Task {
+        await unityRunner.cancelAll()
+    }
+}
+
+@_cdecl("FastVLMUnity_FreeCString")
+public func FastVLMUnity_FreeCString(_ pointer: UnsafeMutablePointer<CChar>?) {
+    guard let pointer else { return }
+    free(pointer)
+}
+
+private func createCString(from string: String?) -> UnsafeMutablePointer<CChar>? {
+    guard let string else { return nil }
+    return strdup(string)
+}

--- a/unity/Plugins/iOS/FastVLMUnityError.swift
+++ b/unity/Plugins/iOS/FastVLMUnityError.swift
@@ -1,0 +1,36 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import Foundation
+
+enum FastVLMUnityError: LocalizedError {
+
+    case modelDirectoryMissing
+    case modelResourcesMissing(String)
+    case imageCreationFailed
+    case unsupportedPixelFormat
+    case invalidPixelBuffer
+    case invalidDimensions
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .modelDirectoryMissing:
+            return "FastVLM model directory has not been configured."
+        case .modelResourcesMissing(let path):
+            return "FastVLM resources were not found at \(path)."
+        case .imageCreationFailed:
+            return "Unable to create an image from the supplied pixel buffer."
+        case .unsupportedPixelFormat:
+            return "The provided pixel format is not supported by the FastVLM Unity plugin."
+        case .invalidPixelBuffer:
+            return "Pixel buffer was null or empty."
+        case .invalidDimensions:
+            return "Width, height, and bytes-per-row must be greater than zero."
+        case .cancelled:
+            return "The FastVLM request was cancelled."
+        }
+    }
+}

--- a/unity/Plugins/iOS/FastVLMUnityImageConverter.swift
+++ b/unity/Plugins/iOS/FastVLMUnityImageConverter.swift
@@ -1,0 +1,77 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import CoreGraphics
+import CoreImage
+import Foundation
+
+@objc enum FastVLMUnityColorFormat: Int {
+    case rgba32 = 0
+    case bgra32 = 1
+}
+
+struct FastVLMUnityImageConverter {
+
+    func makeImage(
+        from data: Data,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        format: FastVLMUnityColorFormat,
+        flipVertical: Bool
+    ) throws -> CIImage {
+        guard !data.isEmpty else {
+            throw FastVLMUnityError.invalidPixelBuffer
+        }
+
+        guard width > 0, height > 0, bytesPerRow > 0 else {
+            throw FastVLMUnityError.invalidDimensions
+        }
+
+        guard let provider = CGDataProvider(data: data as CFData) else {
+            throw FastVLMUnityError.imageCreationFailed
+        }
+
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let bitsPerComponent = 8
+        let bitsPerPixel = 32
+
+        let bitmapInfo: CGBitmapInfo
+        switch format {
+        case .rgba32:
+            var info = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+            info.insert(.byteOrder32Big)
+            bitmapInfo = info
+        case .bgra32:
+            var info = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedFirst.rawValue)
+            info.insert(.byteOrder32Little)
+            bitmapInfo = info
+        }
+
+        guard let cgImage = CGImage(
+            width: width,
+            height: height,
+            bitsPerComponent: bitsPerComponent,
+            bitsPerPixel: bitsPerPixel,
+            bytesPerRow: bytesPerRow,
+            space: colorSpace,
+            bitmapInfo: bitmapInfo,
+            provider: provider,
+            decode: nil,
+            shouldInterpolate: false,
+            intent: .defaultIntent
+        ) else {
+            throw FastVLMUnityError.imageCreationFailed
+        }
+
+        var image = CIImage(cgImage: cgImage)
+        if flipVertical {
+            let transform = CGAffineTransform(scaleX: 1, y: -1).translatedBy(x: 0, y: -CGFloat(height))
+            image = image.transformed(by: transform)
+        }
+
+        return image
+    }
+}

--- a/unity/Plugins/iOS/FastVLMUnityRunner.swift
+++ b/unity/Plugins/iOS/FastVLMUnityRunner.swift
@@ -1,0 +1,173 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+import CoreImage
+import Foundation
+import FastVLM
+import MLX
+import MLXLMCommon
+import MLXRandom
+import MLXVLM
+
+actor FastVLMUnityRunner {
+
+    private enum LoadState {
+        case idle
+        case loading(Task<ModelContainer, Error>)
+        case loaded(ModelContainer)
+    }
+
+    private var loadState: LoadState = .idle
+    private var modelConfiguration: ModelConfiguration?
+    private var modelDirectoryURL: URL?
+    private var generateParameters = GenerateParameters(temperature: 0.0)
+    private var maxTokens: Int = 240
+    private var cancelOnNewRequest = true
+    private var currentTask: Task<String, Error>?
+
+    init() {
+        FastVLM.register(modelFactory: VLMModelFactory.shared)
+        setDefaultModelDirectory()
+    }
+
+    func configure(modelDirectoryPath: String) {
+        if modelDirectoryPath.isEmpty {
+            setDefaultModelDirectory()
+        } else {
+            let url = URL(fileURLWithPath: modelDirectoryPath, isDirectory: true)
+            modelDirectoryURL = url
+            modelConfiguration = ModelConfiguration(directory: url)
+        }
+
+        loadState = .idle
+        currentTask?.cancel()
+        currentTask = nil
+    }
+
+    func setGenerationOptions(temperature: Float, maxTokens: Int) {
+        generateParameters = GenerateParameters(temperature: temperature)
+        self.maxTokens = max(1, maxTokens)
+    }
+
+    func setCancelOnNewRequest(_ cancel: Bool) {
+        cancelOnNewRequest = cancel
+    }
+
+    func loadModel() async throws {
+        _ = try await loadContainer()
+    }
+
+    func generate(ciImage: CIImage, prompt: String) async throws -> String {
+        if cancelOnNewRequest {
+            currentTask?.cancel()
+            currentTask = nil
+        }
+
+        let container = try await loadContainer()
+        let userInput = UserInput(prompt: .text(prompt), images: [.ciImage(ciImage)])
+
+        let task = Task<String, Error> {
+            MLXRandom.seed(UInt64(Date.timeIntervalSinceReferenceDate * 1000))
+
+            let result = try await container.perform { context -> GenerateResult in
+                let input = try await context.processor.prepare(input: userInput)
+                return try MLXLMCommon.generate(
+                    input: input,
+                    parameters: generateParameters,
+                    context: context
+                ) { tokens in
+                    if Task.isCancelled {
+                        return .stop
+                    }
+
+                    return tokens.count >= maxTokens ? .stop : .more
+                }
+            }
+
+            return result.output
+        }
+
+        currentTask = task
+
+        do {
+            let output = try await task.value
+            if currentTask === task {
+                currentTask = nil
+            }
+            return output
+        } catch is CancellationError {
+            if currentTask === task {
+                currentTask = nil
+            }
+            throw FastVLMUnityError.cancelled
+        } catch {
+            if currentTask === task {
+                currentTask = nil
+            }
+            throw error
+        }
+    }
+
+    func cancelAll() {
+        currentTask?.cancel()
+        currentTask = nil
+    }
+
+    private func loadContainer() async throws -> ModelContainer {
+        guard let modelConfiguration, let modelDirectoryURL else {
+            throw FastVLMUnityError.modelDirectoryMissing
+        }
+
+        var isDirectory: ObjCBool = false
+        if !FileManager.default.fileExists(atPath: modelDirectoryURL.path, isDirectory: &isDirectory)
+            || !isDirectory.boolValue
+        {
+            throw FastVLMUnityError.modelResourcesMissing(modelDirectoryURL.path)
+        }
+
+        switch loadState {
+        case .idle:
+            MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
+
+            let task = Task { () throws -> ModelContainer in
+                try await VLMModelFactory.shared.loadContainer(configuration: modelConfiguration)
+            }
+            loadState = .loading(task)
+
+            do {
+                let container = try await task.value
+                loadState = .loaded(container)
+                return container
+            } catch {
+                loadState = .idle
+                throw error
+            }
+
+        case .loading(let task):
+            return try await task.value
+
+        case .loaded(let container):
+            return container
+        }
+    }
+
+    private func setDefaultModelDirectory() {
+        let bundle = Bundle(for: FastVLM.self)
+        let defaultDirectory = bundle
+            .url(forResource: "config", withExtension: "json")?
+            .resolvingSymlinksInPath()
+            .deletingLastPathComponent()
+
+        if let defaultDirectory {
+            modelDirectoryURL = defaultDirectory
+            modelConfiguration = ModelConfiguration(directory: defaultDirectory)
+        } else {
+            modelDirectoryURL = nil
+            modelConfiguration = nil
+        }
+    }
+}
+
+extension FastVLMUnityRunner.LoadState: @unchecked Sendable {}

--- a/unity/README.md
+++ b/unity/README.md
@@ -1,0 +1,159 @@
+# Unity iOS Plugin for FastVLM
+
+This folder contains a native iOS plugin and a managed C# wrapper that expose the on-device FastVLM vision language model to Unity applications. The plugin lets you submit frames from either `Texture2D` assets or live `WebCamTexture` streams and returns the generated string output from FastVLM.
+
+The implementation reuses the Swift components that power the sample app in [`app/`](../app) and wraps them with C-callable entry points that can be invoked from Unity builds targeting iOS 18.2 or later.
+
+## Contents
+
+```
+unity/
+├── Plugins/
+│   └── iOS/
+│       ├── FastVLMUnityBridge.swift      # C-callable bridge between Unity and Swift
+│       ├── FastVLMUnityError.swift       # Plugin error definitions
+│       ├── FastVLMUnityImageConverter.swift
+│       └── FastVLMUnityRunner.swift      # Async actor that orchestrates FastVLM
+├── Runtime/
+│   └── FastVLMUnity.cs                   # Managed C# wrapper used from Unity scripts
+└── README.md
+```
+
+## Prerequisites
+
+- Unity 2022.3 or later with iOS build support.
+- Xcode 16.2 or later targeting iOS 18.2+.
+- Apple Silicon device for running the model on-device.
+- A downloaded FastVLM model (see below).
+
+## Integration steps
+
+1. **Copy the plugin files into your Unity project**
+
+   - Create `Assets/Plugins/iOS/` inside your Unity project if it does not already exist.
+   - Copy the contents of `unity/Plugins/iOS/` from this repository into `Assets/Plugins/iOS/`.
+   - Copy `unity/Runtime/FastVLMUnity.cs` into a folder that is included in your Unity build (for example `Assets/FastVLM/Runtime/`).
+
+2. **Add the FastVLM Swift sources**
+
+   The native plugin depends on the Swift implementation that lives in [`app/FastVLM`](../app/FastVLM). Add the following files to your Unity project (they can also be placed under `Assets/Plugins/iOS/`):
+
+   - `app/FastVLM/FastVLM.swift`
+   - `app/FastVLM/FastVLM.h`
+   - `app/FastVLM/MediaProcessingExtensions.swift`
+
+   When Unity exports the Xcode project, these files will compile into the generated target alongside the plugin bridge.
+
+3. **Install Swift package dependencies in Xcode**
+
+   Open the generated Xcode project (`Unity-iPhone.xcodeproj`) after exporting from Unity and add the following Swift packages (matching the versions used by the sample app):
+
+   - [`https://github.com/ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift) – minimum version **0.21.2**.
+   - [`https://github.com/ml-explore/mlx-swift-examples`](https://github.com/ml-explore/mlx-swift-examples) – minimum version **2.21.2**.
+   - [`https://github.com/huggingface/swift-transformers`](https://github.com/huggingface/swift-transformers) – minimum version **0.1.18**.
+
+   Link the `MLX`, `MLXFast`, `MLXNN`, `MLXRandom`, `MLXLMCommon`, `MLXVLM`, and `Transformers` products to the Unity iOS target. Ensure "Embed & Sign" is enabled for any dynamic frameworks that the packages supply.
+
+4. **Bundle the FastVLM resources**
+
+   Download a FastVLM model using the helper script (run from the repository root):
+
+   ```bash
+   chmod +x app/get_pretrained_mlx_model.sh
+   app/get_pretrained_mlx_model.sh --model 0.5b --dest <some/output/directory>
+   ```
+
+   Copy the resulting directory (which contains `config.json`, weights, tokenizer files, etc.) into a writable location on the device. Two common approaches:
+
+   - Ship the model inside `StreamingAssets` and move it to `Application.persistentDataPath` on first launch, or
+   - Download the model on device and store it in `Application.persistentDataPath`.
+
+   Pass the absolute directory path to `FastVLMUnity.Configure` before loading the model. If you skip configuration the plugin will look for the default resources bundled alongside the Swift sources.
+
+5. **Build and run**
+
+   Build your Unity project for iOS, open the Xcode project, verify that the Swift packages and source files above are present, then deploy to an iOS device running 18.2 or later.
+
+## Using the C# wrapper
+
+The managed wrapper exposes asynchronous helpers to run inferences from Unity scripts.
+
+```csharp
+using System.Threading.Tasks;
+using Apple.FastVLM.Unity;
+using UnityEngine;
+
+public class FastVLMTextureExample : MonoBehaviour
+{
+    [SerializeField] private Texture2D sourceTexture;
+    [TextArea] public string prompt = "Describe this image";
+
+    private async void Start()
+    {
+        // Configure the model directory (optional if you bundled the default resources)
+        string modelDirectory = System.IO.Path.Combine(Application.persistentDataPath, "fastvlm");
+        FastVLMUnity.Configure(modelDirectory);
+
+        await FastVLMUnity.LoadModelAsync();
+
+        string response = await FastVLMUnity.ProcessTextureAsync(sourceTexture, prompt);
+        Debug.Log($"FastVLM response: {response}");
+    }
+}
+```
+
+To work with a live `WebCamTexture`, reuse the same API:
+
+```csharp
+public class FastVLMWebCamExample : MonoBehaviour
+{
+    private WebCamTexture _webCam;
+    [TextArea] public string prompt = "What is happening in this frame?";
+
+    private async void OnEnable()
+    {
+        _webCam = new WebCamTexture();
+        _webCam.Play();
+
+        await FastVLMUnity.LoadModelAsync();
+        InvokeRepeating(nameof(RequestFrameAnalysis), 1.0f, 2.0f);
+    }
+
+    private async void RequestFrameAnalysis()
+    {
+        if (_webCam == null || !_webCam.isPlaying)
+        {
+            return;
+        }
+
+        string response = await FastVLMUnity.ProcessWebCamFrameAsync(_webCam, prompt);
+        Debug.Log($"FastVLM webcam response: {response}");
+    }
+
+    private void OnDisable()
+    {
+        if (_webCam != null)
+        {
+            _webCam.Stop();
+        }
+
+        FastVLMUnity.CancelAll();
+    }
+}
+```
+
+### Additional configuration
+
+- `FastVLMUnity.SetGenerationOptions(float temperature, int maxTokens)` lets you customise sampling.
+- `FastVLMUnity.SetCancelOnNewRequest(bool)` controls whether a new request cancels any in-flight inference (enabled by default).
+- `FastVLMUnity.ProcessRawBytesAsync(...)` provides direct access if you already manage pixel buffers.
+- `FastVLMUnity.CancelAll()` aborts the active inference and clears any pending callbacks.
+
+## Notes & limitations
+
+- The plugin expects RGBA32 or BGRA32 pixel layouts. The helper methods convert Unity `Color32[]` buffers into the correct format automatically.
+- Model loading can take several seconds depending on the model size and device. Always await `LoadModelAsync` before issuing the first inference.
+- Because iOS enforces a watchdog timeout on the main thread, avoid blocking operations. The native plugin executes FastVLM inference asynchronously and delivers the result back on the main thread.
+- Ensure that the downloaded model assets remain readable at runtime (for example, mark copied files with the `Always Included Files` flag if you move them into `StreamingAssets`).
+
+With this setup you can drive FastVLM directly from Unity on iOS, enabling low-latency, on-device multimodal interactions.

--- a/unity/Runtime/FastVLMUnity.cs
+++ b/unity/Runtime/FastVLMUnity.cs
@@ -1,0 +1,406 @@
+//
+// For licensing see accompanying LICENSE file.
+// Copyright (C) 2025 Apple Inc. All Rights Reserved.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AOT;
+using UnityEngine;
+
+namespace Apple.FastVLM.Unity
+{
+    /// <summary>
+    /// Supported pixel formats for the FastVLM Unity plugin.
+    /// </summary>
+    public enum FastVLMUnityPixelFormat
+    {
+        RGBA32 = 0,
+        BGRA32 = 1,
+    }
+
+    /// <summary>
+    /// Managed wrapper around the native FastVLM iOS plugin.
+    /// </summary>
+    public static class FastVLMUnity
+    {
+#if UNITY_IOS && !UNITY_EDITOR
+        private const string DllName = "__Internal";
+
+        private delegate void ResultCallback(int requestId, IntPtr result, IntPtr error);
+        private delegate void StatusCallback(IntPtr error);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_Configure(string modelDirectory);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_SetGenerationOptions(float temperature, int maxTokens);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_SetCancelOnNewRequest(int cancelOnNewRequest);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_LoadModel(StatusCallback callback);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_ProcessImage(
+            int requestId,
+            IntPtr pixelData,
+            int width,
+            int height,
+            int bytesPerRow,
+            int format,
+            int flipVertical,
+            string prompt,
+            ResultCallback callback);
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_CancelAll();
+
+        [DllImport(DllName)]
+        private static extern void FastVLMUnity_FreeCString(IntPtr pointer);
+
+        private static readonly Dictionary<int, TaskCompletionSource<string>> PendingRequests = new();
+        private static readonly object PendingRequestsLock = new();
+        private static int _nextRequestId = 1;
+
+        private static readonly object LoadLock = new();
+        private static TaskCompletionSource<bool>? _loadTask;
+        private static bool _modelLoaded;
+
+        static FastVLMUnity()
+        {
+            SetCancelOnNewRequest(true);
+        }
+
+        /// <summary>
+        /// Configure the plugin with a model directory. If not called, the plugin uses the bundled model configuration.
+        /// </summary>
+        public static void Configure(string modelDirectory)
+        {
+            FastVLMUnity_Configure(modelDirectory ?? string.Empty);
+        }
+
+        /// <summary>
+        /// Configure sampling parameters. Temperature defaults to 0.0 and maxTokens defaults to 240.
+        /// </summary>
+        public static void SetGenerationOptions(float temperature, int maxTokens = 240)
+        {
+            if (maxTokens <= 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(maxTokens), "Max tokens must be positive.");
+            }
+
+            FastVLMUnity_SetGenerationOptions(temperature, maxTokens);
+        }
+
+        /// <summary>
+        /// When enabled, starting a new request cancels the currently running request (default true).
+        /// </summary>
+        public static void SetCancelOnNewRequest(bool cancelPreviousRequests)
+        {
+            FastVLMUnity_SetCancelOnNewRequest(cancelPreviousRequests ? 1 : 0);
+        }
+
+        /// <summary>
+        /// Ensure the model is loaded before issuing inference requests.
+        /// </summary>
+        public static Task LoadModelAsync()
+        {
+            lock (LoadLock)
+            {
+                if (_modelLoaded)
+                {
+                    return Task.CompletedTask;
+                }
+
+                if (_loadTask != null)
+                {
+                    return _loadTask.Task;
+                }
+
+                _loadTask = new TaskCompletionSource<bool>();
+            }
+
+            FastVLMUnity_LoadModel(OnLoadCompleted);
+            return _loadTask!.Task;
+        }
+
+        /// <summary>
+        /// Run FastVLM against a readable Texture2D. Texture data is copied on the CPU prior to dispatch.
+        /// </summary>
+        public static Task<string> ProcessTextureAsync(Texture2D texture, string prompt, bool flipVertical = true)
+        {
+            if (texture == null)
+            {
+                throw new ArgumentNullException(nameof(texture));
+            }
+
+            if (!texture.isReadable)
+            {
+                throw new InvalidOperationException("Texture must be readable. Enable Read/Write on the Texture2D import settings.");
+            }
+
+            Color32[] pixels = texture.GetPixels32();
+            return ProcessColorsAsync(pixels, texture.width, texture.height, prompt, flipVertical);
+        }
+
+        /// <summary>
+        /// Run FastVLM on the latest frame of a WebCamTexture.
+        /// </summary>
+        public static Task<string> ProcessWebCamFrameAsync(WebCamTexture webCamTexture, string prompt, bool flipVertical = true)
+        {
+            if (webCamTexture == null)
+            {
+                throw new ArgumentNullException(nameof(webCamTexture));
+            }
+
+            if (webCamTexture.width <= 0 || webCamTexture.height <= 0)
+            {
+                throw new InvalidOperationException("WebCamTexture has not started streaming yet.");
+            }
+
+            Color32[] pixels = webCamTexture.GetPixels32();
+            return ProcessColorsAsync(pixels, webCamTexture.width, webCamTexture.height, prompt, flipVertical);
+        }
+
+        /// <summary>
+        /// Run FastVLM on raw pixel bytes. Data must remain valid for the duration of the call.
+        /// </summary>
+        public static Task<string> ProcessRawBytesAsync(
+            byte[] pixelBytes,
+            int width,
+            int height,
+            int bytesPerRow,
+            FastVLMUnityPixelFormat format,
+            string prompt,
+            bool flipVertical = true)
+        {
+            if (pixelBytes == null)
+            {
+                throw new ArgumentNullException(nameof(pixelBytes));
+            }
+
+            if (width <= 0 || height <= 0 || bytesPerRow <= 0)
+            {
+                throw new ArgumentOutOfRangeException("Width, height, and bytesPerRow must be positive.");
+            }
+
+            if (pixelBytes.Length < bytesPerRow * height)
+            {
+                throw new ArgumentException("Pixel buffer is smaller than expected for the specified dimensions.", nameof(pixelBytes));
+            }
+
+            var handle = GCHandle.Alloc(pixelBytes, GCHandleType.Pinned);
+            try
+            {
+                return ProcessPinnedBuffer(handle.AddrOfPinnedObject(), width, height, bytesPerRow, format, prompt, flipVertical);
+            }
+            finally
+            {
+                handle.Free();
+            }
+        }
+
+        /// <summary>
+        /// Cancel all pending requests and abort the active inference if possible.
+        /// </summary>
+        public static void CancelAll()
+        {
+            FastVLMUnity_CancelAll();
+
+            lock (PendingRequestsLock)
+            {
+                foreach (TaskCompletionSource<string> pending in PendingRequests.Values)
+                {
+                    pending.TrySetCanceled();
+                }
+
+                PendingRequests.Clear();
+            }
+        }
+
+        private static Task<string> ProcessColorsAsync(Color32[] pixels, int width, int height, string prompt, bool flipVertical)
+        {
+            if (pixels == null)
+            {
+                throw new ArgumentNullException(nameof(pixels));
+            }
+
+            if (width <= 0 || height <= 0)
+            {
+                throw new ArgumentOutOfRangeException("Width and height must be positive.");
+            }
+
+            if (pixels.Length < width * height)
+            {
+                throw new ArgumentException("Pixel buffer does not match the supplied dimensions.", nameof(pixels));
+            }
+
+            byte[] raw = new byte[pixels.Length * 4];
+            Buffer.BlockCopy(pixels, 0, raw, 0, raw.Length);
+            return ProcessRawBytesAsync(raw, width, height, width * 4, FastVLMUnityPixelFormat.RGBA32, prompt, flipVertical);
+        }
+
+        private static Task<string> ProcessPinnedBuffer(
+            IntPtr pixelData,
+            int width,
+            int height,
+            int bytesPerRow,
+            FastVLMUnityPixelFormat format,
+            string prompt,
+            bool flipVertical)
+        {
+            int requestId = Interlocked.Increment(ref _nextRequestId);
+            var tcs = new TaskCompletionSource<string>();
+
+            lock (PendingRequestsLock)
+            {
+                PendingRequests[requestId] = tcs;
+            }
+
+            FastVLMUnity_ProcessImage(
+                requestId,
+                pixelData,
+                width,
+                height,
+                bytesPerRow,
+                (int)format,
+                flipVertical ? 1 : 0,
+                prompt ?? string.Empty,
+                OnProcessCompleted);
+
+            return tcs.Task;
+        }
+
+        [MonoPInvokeCallback(typeof(ResultCallback))]
+        private static void OnProcessCompleted(int requestId, IntPtr resultPtr, IntPtr errorPtr)
+        {
+            string? result = null;
+            string? error = null;
+
+            if (resultPtr != IntPtr.Zero)
+            {
+                result = Marshal.PtrToStringAnsi(resultPtr);
+                FastVLMUnity_FreeCString(resultPtr);
+            }
+
+            if (errorPtr != IntPtr.Zero)
+            {
+                error = Marshal.PtrToStringAnsi(errorPtr);
+                FastVLMUnity_FreeCString(errorPtr);
+            }
+
+            TaskCompletionSource<string>? tcs = null;
+            lock (PendingRequestsLock)
+            {
+                if (PendingRequests.TryGetValue(requestId, out tcs))
+                {
+                    PendingRequests.Remove(requestId);
+                }
+            }
+
+            if (tcs == null)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                tcs.TrySetException(new InvalidOperationException(error));
+            }
+            else if (result != null)
+            {
+                tcs.TrySetResult(result);
+            }
+            else
+            {
+                tcs.TrySetResult(string.Empty);
+            }
+        }
+
+        [MonoPInvokeCallback(typeof(StatusCallback))]
+        private static void OnLoadCompleted(IntPtr errorPtr)
+        {
+            string? error = null;
+            if (errorPtr != IntPtr.Zero)
+            {
+                error = Marshal.PtrToStringAnsi(errorPtr);
+                FastVLMUnity_FreeCString(errorPtr);
+            }
+
+            TaskCompletionSource<bool>? tcs;
+            lock (LoadLock)
+            {
+                tcs = _loadTask;
+                if (string.IsNullOrEmpty(error))
+                {
+                    _modelLoaded = true;
+                }
+                _loadTask = null;
+            }
+
+            if (tcs == null)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(error))
+            {
+                tcs.TrySetException(new InvalidOperationException(error));
+            }
+            else
+            {
+                tcs.TrySetResult(true);
+            }
+        }
+#else
+        public static void Configure(string modelDirectory)
+        {
+            Debug.LogWarning("FastVLMUnity is only available when building for iOS devices.");
+        }
+
+        public static void SetGenerationOptions(float temperature, int maxTokens = 240)
+        {
+        }
+
+        public static void SetCancelOnNewRequest(bool cancelPreviousRequests)
+        {
+        }
+
+        public static Task LoadModelAsync()
+        {
+            return Task.FromException(new PlatformNotSupportedException("FastVLMUnity is only supported on iOS."));
+        }
+
+        public static Task<string> ProcessTextureAsync(Texture2D texture, string prompt, bool flipVertical = true)
+        {
+            return Task.FromException<string>(new PlatformNotSupportedException("FastVLMUnity is only supported on iOS."));
+        }
+
+        public static Task<string> ProcessWebCamFrameAsync(WebCamTexture webCamTexture, string prompt, bool flipVertical = true)
+        {
+            return Task.FromException<string>(new PlatformNotSupportedException("FastVLMUnity is only supported on iOS."));
+        }
+
+        public static Task<string> ProcessRawBytesAsync(
+            byte[] pixelBytes,
+            int width,
+            int height,
+            int bytesPerRow,
+            FastVLMUnityPixelFormat format,
+            string prompt,
+            bool flipVertical = true)
+        {
+            return Task.FromException<string>(new PlatformNotSupportedException("FastVLMUnity is only supported on iOS."));
+        }
+
+        public static void CancelAll()
+        {
+        }
+#endif
+    }
+}


### PR DESCRIPTION
## Summary
- expose C-callable Swift bridge functions that forward Unity requests into the FastVLM runtime
- add actor-based helpers and pixel conversion utilities to manage model configuration, loading, and image preprocessing
- provide a C# wrapper and documentation so Unity projects can invoke the plugin from Texture2D or WebCamTexture sources

## Testing
- not run (Unity/iOS build not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68cf1abd18dc832da7b8256af0ac93de